### PR TITLE
fix compatibility, there are two ergodoxes now

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ This functionality is enabled by default (via `KEYLOGGER_ENABLE` and
 If you are reading this directly through [QMK firmware](https://github.com/jackhumbert/qmk_firmware)'s repository, you can build this layout with the standard method:
 
 ```bash
-$ make keyboard=ergodox keymap=naps62
+$ make keyboard=ergodox_ez keymap=naps62
 ```
 
 If you're reading this from [my own
@@ -83,9 +83,8 @@ checkout this code into QMK's repository. Here's an example:
 ```bash
 $ git clone https://github.com/jackhumbert/qmk_firmware.git
 $ cd qmk_firmware
-$ git clone https://github.com/naps62/ergodox-layout.git
-keyboards/ergodox/keymaps/naps62
-$ make keyboard=ergodox keymap=naps62
+$ git clone https://github.com/naps62/ergodox-layout.git keyboards/ergodox_ez/keymaps/naps62
+$ make keyboard=ergodox_ez keymap=naps62
 ```
 
 ## Author

--- a/keymap.c
+++ b/keymap.c
@@ -1,5 +1,5 @@
 #include <stdarg.h>
-#include "ergodox.h"
+#include "ergodox_ez.h"
 #include "debug.h"
 #include "action_layer.h"
 
@@ -41,7 +41,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
  */
 // If it accepts an argument (i.e, is a function), it doesn't need KC_.
 // Otherwise, it needs KC_*
-[BASE] = KEYMAP(  // layer 0 : default
+[BASE] = LAYOUT_ergodox(  // layer 0 : default
   // left hand
   KC_ESC,     KC_1,    KC_2,     KC_3,     KC_4,   KC_5,  LANG_SWITCH,
   KC_TAB,     KC_Q,    KC_W,     KC_E,     KC_R,   KC_T,  MO(2),
@@ -86,7 +86,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
  *                                 `--------------------'       `--------------------'
  */
 // SYMBOLS
-[SYMB] = KEYMAP(
+[SYMB] = LAYOUT_ergodox(
        // left hand
        KC_TRNS,KC_F1,  KC_F2,  KC_F3,  KC_F4,  KC_F5,  KC_TRNS,
        KC_TRNS,KC_EXLM,KC_AT,  KC_LCBR,KC_RCBR,KC_PIPE,KC_TRNS,
@@ -130,7 +130,7 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
  *                                 `--------------------'       `--------------------'
  */
 // MEDIA AND MOUSE
-KEYMAP(
+LAYOUT_ergodox(
          RESET, KC_TRNS,        KC_TRNS,     KC_TRNS,        KC_TRNS, KC_TRNS,    KC_TRNS,
        KC_TRNS, KC_TRNS,        KC_TRNS,     KC_TRNS,        KC_TRNS, KC_TRNS,    KC_TRNS,
        KC_TRNS, KC_TRNS,        KC_TRNS,     KC_TRNS,        KC_TRNS, KC_TRNS,


### PR DESCRIPTION
Hey, there is no "ergodox" keyboard anymore, there are ergodox_ez and ergodox_infinity ones, I guessed that you had ergodox_ez according to the images, so I fixed it and now it can be compiled with qmk_firmware master branch.